### PR TITLE
fix(readme): correct snm link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ My Dotfiles includes configs for vim, tmux, zsh, fzf and more. Made with blood, 
 -   [exa](https://github.com/ogham/exa) (A modern replacement for ‘ls’)
 -   [zoxide](https://github.com/ajeetdsouza/zoxide) (A faster way to navigate your filesystem)
 -   [yarn](https://github.com/yarnpkg/yarn) (Yarn package manager for Nodejs)
--   [snm](https://github.com/ogham/exa) (Version Manager for Nodejs)
+-   [snm](https://github.com/numToStr/snm) (Version Manager for Nodejs)
 
 #### Fonts
 


### PR DESCRIPTION
snm is linked to exa project page.